### PR TITLE
Table sort

### DIFF
--- a/app/actions/player_matches_act.js
+++ b/app/actions/player_matches_act.js
@@ -50,10 +50,10 @@ export function changeSortedby(sortedBy) {
     };
 }
 
-export function sortMatches(sortColumn, sortDirection) {
+export function sortMatches(sortField, sortDirection) {
     return {
         type: types.SORT_MATCHES,
-        sortColumn,
+        sortField,
         sortDirection
     }
 }

--- a/app/actions/player_matches_act.js
+++ b/app/actions/player_matches_act.js
@@ -5,6 +5,7 @@ export const types = {
     RECEIVE_MATCHES: 'RECEIVE_MATCHES',
     RECEIVE_EMPTY_MATCHES: 'RECEIVE_EMPTY_MATCHES',
     CHANGE_SORTED_BY: 'CHANGE_SORTED_BY',
+    SORT_MATCHES: 'SORT_MATCHES',
     NAVIGATE_NEXT_MATCHES: 'NAVIGATE_NEXT_MATCHES',
     NAVIGATE_PREVIOUS_MATCHES: 'NAVIGATE_PREVIOUS_MATCHES'
 }
@@ -47,6 +48,14 @@ export function changeSortedby(sortedBy) {
         type: types.CHANGE_SORTED_BY,
         sortedBy
     };
+}
+
+export function sortMatches(sortColumn, sortDirection) {
+    return {
+        type: types.SORT_MATCHES,
+        sortColumn,
+        sortDirection
+    }
 }
 
 export function fetchMatches(playerId, limit, projects, sortCategory, heroId, result,

--- a/app/components/MatchesCard.js
+++ b/app/components/MatchesCard.js
@@ -289,19 +289,11 @@ class MatchesCard extends Component {
     render() {
         if(this.props.matches) {
             var dynamicHeader = this.getHeader();
-
-            var sortDirection = "";
-            if(!this.props.sortDirection || this.props.sortDirection === "ASC") {
-                sortDirection = "DESC";
-            } else if (this.props.sortDirection === "DESC") {
-                sortDirection = "ASC";
-            }
-
-            let dynamicText = <Text numberOfLines = {1} style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>{dynamicHeader}</Text>;
+            var dynamicText = <Text numberOfLines = {1} style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>{dynamicHeader}</Text>;
 
             if (dynamicHeader === 'K/D/A') {
                 dynamicText = (
-                    <TouchableOpacity onPress = {() => {this.props.sortMatches("kda", sortDirection)}}>
+                    <TouchableOpacity onPress = {() => {this.props.sortMatches("kda", this.props.sortDirection)}}>
                         {dynamicText}
                     </TouchableOpacity>
                 );
@@ -326,12 +318,12 @@ class MatchesCard extends Component {
                             <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Mode</Text>
                         </View>
                         <View style = {styles.tableHeaderCell}>
-                            <TouchableOpacity onPress = {() => {this.props.sortMatches("ended", sortDirection)}}>
+                            <TouchableOpacity onPress = {() => {this.props.sortMatches("ended", this.props.sortDirection)}}>
                                 <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Ended</Text>
                             </TouchableOpacity>
                         </View>
                         <View style = {styles.tableHeaderCell}>
-                            <TouchableOpacity onPress = {() => {this.props.sortMatches("duration", sortDirection)}}>
+                            <TouchableOpacity onPress = {() => {this.props.sortMatches("duration", this.props.sortDirection)}}>
                                 <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Length</Text>
                             </TouchableOpacity>
                         </View>

--- a/app/components/MatchesCard.js
+++ b/app/components/MatchesCard.js
@@ -30,6 +30,7 @@ export const mapStateToProps = state => ({
     legend: state.settingsState.legend,
     secondLegend: state.settingsState.secondLegend,
     sortedBy: state.playerMatchesState.sortedBy,
+    sortDirection: state.playerMatchesState.sortDirection,
     parent: state.navigationState.parent
 });
 
@@ -49,7 +50,7 @@ class MatchesCard extends Component {
     matchPressed(data) {
         var matchId = data.match_id;
         if(this.props.parent == "Favourites") {
-            Actions.mastchDetailsFavourite(matchId);
+            Actions.matchDetailsFavourite(matchId);
         } else if (this.props.parent == "Search") {
             Actions.matchDetailsSearch(matchId);
         } else if (this.props.parent == "Home") {
@@ -289,6 +290,23 @@ class MatchesCard extends Component {
         if(this.props.matches) {
             var dynamicHeader = this.getHeader();
 
+            var sortDirection = "";
+            if(!this.props.sortDirection || this.props.sortDirection === "ASC") {
+                sortDirection = "DESC";
+            } else if (this.props.sortDirection === "DESC") {
+                sortDirection = "ASC";
+            }
+
+            let dynamicText = <Text numberOfLines = {1} style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>{dynamicHeader}</Text>;
+
+            if (dynamicHeader === 'K/D/A') {
+                dynamicText = (
+                    <TouchableOpacity onPress = {() => {this.props.sortMatches("kda", sortDirection)}}>
+                        {dynamicText}
+                    </TouchableOpacity>
+                );
+            }
+
             return (
                 <View style = {[styles.matchesCardContainer, {backgroundColor: this.props.mod}]}>
                     <View style = {styles.titleContainer}>
@@ -308,13 +326,17 @@ class MatchesCard extends Component {
                             <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Mode</Text>
                         </View>
                         <View style = {styles.tableHeaderCell}>
-                            <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Ended</Text>
+                            <TouchableOpacity onPress = {() => {this.props.sortMatches("ended", sortDirection)}}>
+                                <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Ended</Text>
+                            </TouchableOpacity>
                         </View>
                         <View style = {styles.tableHeaderCell}>
-                            <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Length</Text>
+                            <TouchableOpacity onPress = {() => {this.props.sortMatches("duration", sortDirection)}}>
+                                <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Length</Text>
+                            </TouchableOpacity>
                         </View>
                         <View style = {styles.doubleTableHeaderCell}>
-                            <Text numberOfLines = {1} style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>{dynamicHeader}</Text>
+                            {dynamicText}
                         </View>
                         <View style = {{width: 5}} />
                     </View>

--- a/app/containers/DotaKeepApp.js
+++ b/app/containers/DotaKeepApp.js
@@ -55,7 +55,7 @@ class DotaKeepApp extends Component {
                                 <Scene key = "favourite" component = {Favourite} title = "Favourites"/>
                                 <Scene clone = {true} key = "playerProfileFavourite" component = {PlayerProfile} title = "Player Profile" panHandlers = {null} navBar = {deepNavBar} />
                                 <Scene clone = {true} key = "matchesSearchFavourite" component = {MatchesSearch} title = "Search Matches" direction = 'vertical' panHandlers = {null} navBar = {modalNavBar} />
-                                <Scene clone = {true} key = "mastchDetailsFavourite" component = {MatchDetailsPage} title = "Match Details" panHandlers = {null} navBar = {MatchNavBar} />
+                                <Scene clone = {true} key = "matchDetailsFavourite" component = {MatchDetailsPage} title = "Match Details" panHandlers = {null} navBar = {MatchNavBar} />
                             </Scene>
                             <Scene key = "searchTab" title = "Search" navBar = {customNavBar}>
                                 <Scene key = "playerSearch" component = {PlayerSearch} title = "Search Profile" />

--- a/app/containers/MatchOverview.js
+++ b/app/containers/MatchOverview.js
@@ -39,6 +39,8 @@ import Colors from '../themes/Colors';
 import base from '../themes/BaseStyles';
 import Fonts from '../themes/Fonts';
 
+import { defaultSort, SORT_ENUM } from '../utils/sorting';
+
 export const mapStateToProps = state => ({
     matchDetails: state.matchDetailsState.matchDetails,
     isLoadingMatchDetails: state.matchDetailsState.isLoadingMatchDetails,
@@ -90,7 +92,11 @@ class MatchOverview extends Component {
             averageMMR: -1,
             skill: "",
             radiantGoldAdvantage: [],
-            radiantXpAdvantage: []
+            radiantXpAdvantage: [],
+            radiantSortField: "",            
+            radiantSortDirection: "",
+            direSortField: "",
+            direSortDirection: ""
         };
         this.generateProcessedPlayers = this.generateProcessedPlayers.bind(this);
         this.generateProcessedData = this.generateProcessedData.bind(this);
@@ -101,6 +107,7 @@ class MatchOverview extends Component {
         this.onRowPressed = this.onRowPressed.bind(this);
         this.onNamePressed = this.onNamePressed.bind(this);
         this.normalizeGameMode = this.normalizeGameMode.bind(this);
+        this.sortPlayers = this.sortPlayers.bind(this);
     }
 
     componentDidMount() {
@@ -214,6 +221,28 @@ class MatchOverview extends Component {
             normalized += split[i].charAt(0).toUpperCase() + split[i].slice(1) + " ";
         }
         return normalized;
+    }
+
+    sortPlayers(array, sortField, sortDirection, isRadiant) {
+        var obj = {};
+
+        if (isRadiant) {
+            obj.radiantSortField = sortField;
+            obj.radiantSortDirection = 
+                sortField === this.state.radiantSortField ? 
+                SORT_ENUM.next(SORT_ENUM[sortDirection]) : 
+                SORT_ENUM[0]
+            obj.radiantsPlayerList = defaultSort(array, sortField, obj.radiantSortDirection);
+        } else {
+            obj.direSortField = sortField;
+            obj.direSortDirection = 
+                sortField === this.state.direSortField ? 
+                SORT_ENUM.next(SORT_ENUM[sortDirection]) : 
+                SORT_ENUM[0]
+            obj.direPlayersList = defaultSort(array, sortField, obj.direSortDirection);
+        }
+
+        this.setState(obj)
     }
 
     calculateAverageMMR(data) {
@@ -826,16 +855,24 @@ class MatchOverview extends Component {
                                         <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Hero</Text>
                                     </View>
                                     <View style = {styles.tableHeaderCell}>
-                                        <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Player</Text>
+                                        <TouchableOpacity onPress = {() => this.sortPlayers(this.state.radiantPlayersList, "player", this.state.radiantSortDirection, true)}>
+                                            <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Player</Text>
+                                        </TouchableOpacity>
                                     </View>
                                     <View style = {styles.tableHeaderCell}>
-                                        <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>K/D/A</Text>
+                                        <TouchableOpacity onPress = {() => this.sortPlayers(this.state.radiantPlayersList, "kda", this.state.radiantSortDirection, true)}>
+                                            <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>K/D/A</Text>
+                                        </TouchableOpacity>
                                     </View>
                                     <View style = {styles.tableHeaderCell}>
-                                        <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>GPM</Text>
+                                        <TouchableOpacity onPress = {() => this.sortPlayers(this.state.radiantPlayersList, "gpm", this.state.radiantSortDirection, true)}>
+                                            <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>GPM</Text>
+                                        </TouchableOpacity>
                                     </View>
                                     <View style = {styles.tableHeaderCell}>
-                                        <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>XPM</Text>
+                                        <TouchableOpacity onPress = {() => this.sortPlayers(this.state.radiantPlayersList, "xpm", this.state.radiantSortDirection, true)}>
+                                            <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>XPM</Text>
+                                        </TouchableOpacity>
                                     </View>
                                 </View>
                                 <ListView style = {styles.matchesListView}
@@ -860,16 +897,24 @@ class MatchOverview extends Component {
                                         <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Hero</Text>
                                     </View>
                                     <View style = {styles.tableHeaderCell}>
-                                        <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Player</Text>
+                                        <TouchableOpacity onPress = {() => this.sortPlayers(this.state.direPlayersList, "player", this.state.direSortDirection)}>
+                                            <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>Player</Text>
+                                        </TouchableOpacity>
                                     </View>
                                     <View style = {styles.tableHeaderCell}>
-                                        <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>K/D/A</Text>
+                                        <TouchableOpacity onPress = {() => this.sortPlayers(this.state.direPlayersList, "kda", this.state.direSortDirection)}>
+                                            <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>K/D/A</Text>
+                                        </TouchableOpacity>
                                     </View>
                                     <View style = {styles.tableHeaderCell}>
-                                        <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>GPM</Text>
+                                        <TouchableOpacity onPress = {() => this.sortPlayers(this.state.direPlayersList, "gpm", this.state.direSortDirection)}>
+                                            <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>GPM</Text>
+                                        </TouchableOpacity>
                                     </View>
                                     <View style = {styles.tableHeaderCell}>
-                                        <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>XPM</Text>
+                                        <TouchableOpacity onPress = {() => this.sortPlayers(this.state.direPlayersList, "xpm", this.state.direSortDirection)}>
+                                            <Text style = {[styles.tableHeaderText, {color: this.props.secondLegend}]}>XPM</Text>
+                                        </TouchableOpacity>
                                     </View>
                                 </View>
                                 <ListView style = {styles.matchesListView}

--- a/app/containers/MatchesPage.js
+++ b/app/containers/MatchesPage.js
@@ -29,7 +29,7 @@ export const mapStateToProps = state => ({
     isLoadingMatches: state.playerMatchesState.isLoadingMatches,
     isEmptyMatches: state.playerMatchesState.isEmptyMatches,
     page: state.playerMatchesState.page,
-    sortColumn: state.playerMatchesState.sortColumn,
+    sortField: state.playerMatchesState.sortField,
     sortDirection: state.playerMatchesState.sortDirection,
     contextId: state.navigationState.contextId,
     legendHex: state.settingsState.legendHex,
@@ -107,8 +107,8 @@ class MatchesPage extends Component {
         }
     }
 
-    sortMatches(sortColumn, sortDirection) {
-        this.props.actions.sortMatches(sortColumn, sortDirection);
+    sortMatches(sortField, sortDirection) {
+        this.props.actions.sortMatches(sortField, sortDirection);
     }
 
     componentWillMount() {

--- a/app/containers/MatchesPage.js
+++ b/app/containers/MatchesPage.js
@@ -29,6 +29,8 @@ export const mapStateToProps = state => ({
     isLoadingMatches: state.playerMatchesState.isLoadingMatches,
     isEmptyMatches: state.playerMatchesState.isEmptyMatches,
     page: state.playerMatchesState.page,
+    sortColumn: state.playerMatchesState.sortColumn,
+    sortDirection: state.playerMatchesState.sortDirection,
     contextId: state.navigationState.contextId,
     legendHex: state.settingsState.legendHex,
     legend: state.settingsState.legend,
@@ -80,6 +82,8 @@ class MatchesPage extends Component {
         this.state = {
             refreshing: false
         };
+
+        this.sortMatches = this.sortMatches.bind(this);
     }
 
     componentDidMount() {
@@ -101,6 +105,10 @@ class MatchesPage extends Component {
         } else if (this.props.parent == "Home") {
             Actions.matchesSearchHome();
         }
+    }
+
+    sortMatches(sortColumn, sortDirection) {
+        this.props.actions.sortMatches(sortColumn, sortDirection);
     }
 
     componentWillMount() {
@@ -217,7 +225,7 @@ class MatchesPage extends Component {
                     <Text style = {styles.filterText}>
                         {this.initialValue} - {this.endValue} of {this.totalMatches} matches
                     </Text>
-                    <MatchesCard matches = {this.matchesSubset} default = {false} />
+                    <MatchesCard matches = {this.matchesSubset} sortMatches = {this.sortMatches} default = {false} />
                     {this.pageControl}
                     <Text style = {styles.filterText}>
                         {this.initialValue} - {this.endValue} of {this.totalMatches} matches

--- a/app/reducers/player_matches_rdx.js
+++ b/app/reducers/player_matches_rdx.js
@@ -11,6 +11,30 @@ export default function playerMatchesState(state = initialState, action = {}) {
             return Object.assign({}, state, { isLoadingMatches: false, isEmptyMatches: true, matches: {} });
         case types.CHANGE_SORTED_BY:
             return Object.assign({}, state, { sortedBy: action.sortedBy });
+        case types.SORT_MATCHES:
+            var matches = state.matches;
+            var reversed = 1;
+
+            if (action.sortDirection === "ASC" && state.sortColumn === action.sortColumn) {
+                reversed = -1;
+            }
+
+            matches.sort((a, b) => {
+                var x = a[action.sortColumn];
+                var y = b[action.sortColumn];
+
+                if(action.sortColumn === "ended") {
+                    x = a.start_time + a.duration;
+                    y = b.start_time + b.duration
+                } else if (action.sortColumn === "kda") {
+                    x = (a.kills + a.assists) / (a.deaths);
+                    y = (b.kills + b.assists) / (b.deaths);
+                }
+
+                return ((x < y) ? reversed * -1 : ((x > y) ? reversed * 1 : 0))
+            });
+
+            return Object.assign({}, state, { sortColumn: action.sortColumn, sortDirection: action.sortDirection, matches });
         case types.NAVIGATE_NEXT_MATCHES:
             newPage = state.page + action.amount;
 

--- a/app/reducers/player_matches_rdx.js
+++ b/app/reducers/player_matches_rdx.js
@@ -1,5 +1,7 @@
 import { types } from '../actions/player_matches_act';
-var initialState = { isLoadingMatches: false, isEmptyMatches: false, matches: {}, sortedBy: "match_id", page: 1 };
+import { defaultSort, SORT_ENUM } from '../utils/sorting';
+
+var initialState = { isLoadingMatches: false, isEmptyMatches: false, matches: {}, sortedBy: "match_id", page: 1, sortField: "", sortDirection: "" };
 
 export default function playerMatchesState(state = initialState, action = {}) {
     switch(action.type) {
@@ -13,28 +15,10 @@ export default function playerMatchesState(state = initialState, action = {}) {
             return Object.assign({}, state, { sortedBy: action.sortedBy });
         case types.SORT_MATCHES:
             var matches = state.matches;
-            var reversed = 1;
+            var sortDirection = action.sortField === state.sortField ? SORT_ENUM.next(SORT_ENUM[action.sortDirection]) : SORT_ENUM[0];
+            matches = defaultSort(matches, action.sortField, sortDirection);
 
-            if (action.sortDirection === "ASC" && state.sortColumn === action.sortColumn) {
-                reversed = -1;
-            }
-
-            matches.sort((a, b) => {
-                var x = a[action.sortColumn];
-                var y = b[action.sortColumn];
-
-                if(action.sortColumn === "ended") {
-                    x = a.start_time + a.duration;
-                    y = b.start_time + b.duration
-                } else if (action.sortColumn === "kda") {
-                    x = (a.kills + a.assists) / (a.deaths);
-                    y = (b.kills + b.assists) / (b.deaths);
-                }
-
-                return ((x < y) ? reversed * -1 : ((x > y) ? reversed * 1 : 0))
-            });
-
-            return Object.assign({}, state, { sortColumn: action.sortColumn, sortDirection: action.sortDirection, matches });
+            return Object.assign({}, state, { sortField: action.sortField, sortDirection: sortDirection, matches });
         case types.NAVIGATE_NEXT_MATCHES:
             newPage = state.page + action.amount;
 

--- a/app/utils/sorting.js
+++ b/app/utils/sorting.js
@@ -1,0 +1,25 @@
+export const defaultSort = (array, sortField, sortDirection) =>
+    array.sort((a, b) => {
+        let x = (a[sortField]);
+        let y = (b[sortField]);
+        
+        if(sortField === "ended") {
+            x = a.start_time + a.duration;
+            y = b.start_time + b.duration
+        } else if (sortField === "kda") {
+            x = (a.kills + a.assists) / (a.deaths);
+            y = (b.kills + b.assists) / (b.deaths);
+        }
+
+        const desc = x < y ? 1 : -1;
+        const asc = x < y ? -1 : 1;
+        return sortDirection === "desc" ? desc : asc;
+    });
+
+export const SORT_ENUM = {
+    0: "asc",
+    1: "desc",
+    asc: 0,
+    desc: 1,
+    next: state => SORT_ENUM[(state >= 1 ? 0 : state + 1)],
+};


### PR DESCRIPTION
For feature https://github.com/odota/mobile/issues/6.

- Added sorting for kda, ended and duration on matches card page (this sorts on the redux store)

- Added sorting for player name, kda, gpm and xpm on the match details page (sorts on component's local state)

- Added sorting utility function and enum that was taken from the opendota UI project.

- Fixed minor typo mastchDetailsFavourite -> matchDetailsFavourite