### PR TITLE
Add eslint for improving code consistency

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true,
+      "modules": true,
+      "experimentalObjectRestSpread": true
+    }
+  },
+  "env": {
+    "amd": true,
+    "node": true
+  },
+  "plugins": [
+    "react",
+    "react-native"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "react-native start",
-    "clear": "npm cache clean && watchman watch-del-all && rm -rf $TMPDIR/react-*"
+    "clear": "npm cache clean && watchman watch-del-all && rm -rf $TMPDIR/react-*",
+    "lint": "eslint app/*"
   },
   "dependencies": {
     "dotaconstants": "5.15.0",
@@ -34,6 +35,10 @@
     "redux-thunk": "2.2.0"
   },
   "devDependencies": {
+    "babel-eslint": "^8.0.3",
+    "eslint": "^4.13.1",
+    "eslint-plugin-react": "^7.5.1",
+    "eslint-plugin-react-native": "^3.2.0",
     "redux-logger": "3.0.6",
     "request": "2.83.0"
   }


### PR DESCRIPTION
Closes #99

This is a PR to add ESLint to the project. Using some default rules, ESLint has identified 678 problems that should be fixed.

Running `npm run lint` will produce output:

<img width="725" alt="screen shot 2017-12-19 at 1 14 17 pm" src="https://user-images.githubusercontent.com/1088336/34172042-973a31d4-e4be-11e7-8dbb-76f119d56c6c.png">

Moving forward, I think we should create new github issues for each relevant folder under the `/app` directory to clean up all the lint warnings for that particular folder (since it would be a gigantic PR/a lot of work to fix everything at once). 

After we get the project to a good state, we can run the linter as a git pre-commit hook (using husky and lint-staged) to help identify code that should be cleaned up before it gets committed. 

Thoughts?