### PR TITLE
Add Travis CI & Fix lint warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,8 @@
   },
   "env": {
     "amd": true,
-    "node": true
+    "node": true,
+    "browser": true
   },
   "plugins": [
     "react",
@@ -22,6 +23,7 @@
     "plugin:react/recommended"
   ],
   "rules": {
-    "react/prop-types": 0
+    "react/prop-types": 0,
+    "no-console": 1
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "9.5.0"
+script:
+  - npm run lint

--- a/app/utils/fetch.js
+++ b/app/utils/fetch.js
@@ -36,7 +36,7 @@ export function fetchAPI(endpoint, method = 'get', data) {
                     let errStr = '';
                     let errors = _.omit(error, ['column', 'line', 'sourceURL'])
 
-                    _.forEach(errors, function (value, key) {
+                    _.forEach(errors, function (value) {
                         errStr += value + '.\n';
                     });
 

--- a/app/utils/heatmapUtils.js
+++ b/app/utils/heatmapUtils.js
@@ -1,7 +1,3 @@
-const degToRad = (deg) => {
-    return deg * Math.PI / 180;
-};
-
 const values = (obj) => {
     const array = [];
     for (const key in obj) {


### PR DESCRIPTION
Travis is a Continuous Integration tool that builds each branch and PR. You'd have to enable Travis for your project [here](https://travis-ci.org/) if you want to use it.

Right now it just runs the linter, so you can tell if any of PRs fail with lint errors. But it can also run tests and upload iOS and Android builds to [Github releases](https://github.com/odota/mobile/releases) (if that's something you're interested in)

---
Fixed lint errors & downgraded console.log statements to be a warning instead of an error