### PR TITLE
run error: cannot import react-native-root-toast

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-native-device-info": "0.22.5",
     "react-native-google-analytics-bridge": "6.1.0",
     "react-native-keyboard-aware-scroll-view": "0.7.2",
-    "react-native-root-toast": "git+https://github.com/magicismight/react-native-root-siblings.git",
+    "react-native-root-siblings": "git+https://github.com/magicismight/react-native-root-siblings.git",
+    "react-native-root-toast": "git+https://github.com/magicismight/react-native-root-toast.git",
     "react-native-router-flux": "4.0.0-beta.31",
     "react-native-scrollable-tab-view": "git+https://github.com/happypancake/react-native-scrollable-tab-view.git",
     "react-native-simple-radio-button": "^2.7.1",
@@ -35,7 +36,7 @@
     "react-native-svg-charts": "git+https://github.com/Proyoyo/react-native-svg-charts.git",
     "react-native-vector-icons": "5.0.0",
     "react-redux": "5.0.6",
-    "redux": "3.7.2",
+    "redux": "^3.7.2",
     "redux-thunk": "2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I fork odota/mobile and run for the first time today.

An error related to import Toast from 'react-native-root-toast' appeared, as shown in attached image
![import-bug](https://user-images.githubusercontent.com/31865045/47253364-79df7e00-d48c-11e8-8e68-39655bba4540.png)

The workaround for this bug is similar to this comment
https://github.com/magicismight/react-native-root-toast/issues/88#issuecomment-428424540

This bug occurs when I update package using npm
With yarn, it is OK.
I built on Mac, IDE is WebStorm.
