### PR TITLE
Lock down googlePlayServicesVersion and firebaseVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,8 @@
 
 buildscript {
     ext {
-        googlePlayServicesVersion = "+"
+        googlePlayServicesVersion = "16.+"
+        firebaseVersion = "17.3.4"
     }
     repositories {
         configurations.all {


### PR DESCRIPTION
https://github.com/odota/mobile/issues/146

Might be worth checking if the builds _actually_ fail before reviewing this PR. However, I'm 99% sure they will as the app uses react-native-device-info 

react-native-device-info maintainer confirmed that the library will break: https://github.com/facebook/react-native/issues/25293#issuecomment-503140217